### PR TITLE
Fix missing / in WAYLAND_SOCKET

### DIFF
--- a/pacwrap-core/src/constants.rs
+++ b/pacwrap-core/src/constants.rs
@@ -81,7 +81,7 @@ lazy_static! {
     pub static ref CONFIG_FILE: &'static str = format_str!("{}/pacwrap.yml", *CONFIG_DIR);
     pub static ref XDG_RUNTIME_DIR: String = format!("/run/user/{}", *UID);
     pub static ref DBUS_SOCKET: String = format!("/run/user/{}/pacwrap_dbus_{}", *UID, &id());
-    pub static ref WAYLAND_SOCKET: String = format!("{}{}", *XDG_RUNTIME_DIR, *WAYLAND_DISPLAY);
+    pub static ref WAYLAND_SOCKET: String = format!("{}/{}", *XDG_RUNTIME_DIR, *WAYLAND_DISPLAY);
     pub static ref LOG_LOCATION: &'static str = format_str!("{}/pacwrap.log", *DATA_DIR);
     pub static ref UNIX_TIMESTAMP: u64 = unix_epoch_time().as_secs();
     pub static ref IS_COLOR_TERMINAL: bool = is_color_terminal();


### PR DESCRIPTION
Firstly, thanks for making pacwrap!
## Issue
When trying to launch Firefox (or really anything if the "display" module is enabled) I get an error that the file "/run/user/1000wayland-0" doesn't exist
## Fix
 As far as I know, the right path is "/run/user/1000/wayland-0". After making this change, the error doesn't occur anymore. (Firefox still doesn't work, but I think this is because of skill issues on my side)